### PR TITLE
modifications to get cdk destroy to work cleanly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ test:
 build:
 	@echo "Building the project..."
 	npx tsc --project tsconfig.build.json
+	npm link
 
 # Generate documentation
 docs: clean-docs docs/typedoc

--- a/lib/ACM/ssl_cert.ts
+++ b/lib/ACM/ssl_cert.ts
@@ -3,14 +3,55 @@ import * as acm from 'aws-cdk-lib/aws-certificatemanager';
 import * as route53 from 'aws-cdk-lib/aws-route53';
 import { Construct } from 'constructs';
 
-interface SslCertProps extends cdk.StackProps {
+export interface DxCertificateProps {
+    subDomainName: string;
+    hostedZoneId: string
+    region?: string;  // Optional: for cross-region certs
+    subjectAlternativeNames?: string[];  // Optional: SANs
+}
+
+export class DxCertificate extends Construct {
+    public readonly certificate: acm.Certificate;
+
+    constructor(scope: Construct, id: string, props: DxCertificateProps) {
+        super(scope, id);
+
+        // Import an existing hosted zone
+        const subDomainHostedZone = route53.HostedZone.fromHostedZoneAttributes(this, 'SubDomainHostedZone', {
+            zoneName: props.subDomainName,
+            hostedZoneId: props.hostedZoneId  // We'll need to pass this in
+        });
+
+        this.certificate = new acm.Certificate(this, 'Certificate', {
+            domainName: props.subDomainName,
+            validation: acm.CertificateValidation.fromDns(subDomainHostedZone),
+            subjectAlternativeNames: props.subjectAlternativeNames,
+            // If region is specified, create in that region
+            ...(props.region && { region: props.region })
+        });
+
+        // Add outputs
+        new cdk.CfnOutput(this, 'CertificateArn', {
+            value: this.certificate.certificateArn,
+            description: 'The ARN of the certificate'
+        });
+    }
+
+    public get certificateArn(): string {
+        return this.certificate.certificateArn;
+    }
+}
+
+/*
+
+interface DxSSLCertProps extends cdk.StackProps {
     subDomainName: string; // e.g., "dev.example.com"
 }
 
-export class SslCertStack extends Construct {
+export class DxSSLCert extends Construct {
     public readonly certificate: acm.Certificate;
 
-    constructor(scope: Construct, id: string, props: SslCertProps) {
+    constructor(scope: Construct, id: string, props: DxSSLCertProps) {
         super(scope, id);
 
         const { subDomainName } = props;

--- a/lib/Route53/dx-dns.ts
+++ b/lib/Route53/dx-dns.ts
@@ -1,7 +1,9 @@
 import * as cdk from 'aws-cdk-lib';
 import * as route53 from 'aws-cdk-lib/aws-route53';
 import * as iam from 'aws-cdk-lib/aws-iam';
-import {Construct} from "constructs";
+import * as cr from 'aws-cdk-lib/custom-resources';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import { Construct } from "constructs";
 
 interface DxDnsProps extends cdk.StackProps {
     subDomainName: string; // e.g., "dev.example.com"
@@ -24,9 +26,86 @@ export class DxDns extends Construct {
         this.hostedZoneId = props.hostedZoneId;
     }
 
+    /*
     public createSubdomainHostedZone(): void {
         this.subDomainHostedZone = new route53.PublicHostedZone(this, 'SubDomainHostedZone', {
             zoneName: this.subDomainName,
+        });
+        this.subDomainHostedZone.applyRemovalPolicy(cdk.RemovalPolicy.DESTROY);
+    }
+
+     */
+    public createSubdomainHostedZone(): void {
+        this.subDomainHostedZone = new route53.PublicHostedZone(this, 'SubDomainHostedZone', {
+            zoneName: this.subDomainName,
+        });
+        this.subDomainHostedZone.applyRemovalPolicy(cdk.RemovalPolicy.DESTROY);
+
+        // Create a custom resource to clean up records
+        const cleanupProvider = new cr.Provider(this, 'CleanupProvider', {
+            onEventHandler: new lambda.Function(this, 'CleanupFunction', {
+                runtime: lambda.Runtime.NODEJS_18_X,
+                handler: 'index.handler',
+                code: lambda.Code.fromInline(`
+                const { Route53Client, ListResourceRecordSetsCommand, ChangeResourceRecordSetsCommand } = require('@aws-sdk/client-route-53');
+                const client = new Route53Client();
+                
+                exports.handler = async (event) => {
+                    console.log('Event:', JSON.stringify(event, null, 2));
+                    
+                    if (event.RequestType === 'Delete') {
+                        const zoneId = event.ResourceProperties.hostedZoneId;
+                        console.log('Cleaning up hosted zone:', zoneId);
+                        
+                        try {
+                            // Get all records
+                            const listCommand = new ListResourceRecordSetsCommand({
+                                HostedZoneId: zoneId
+                            });
+                            const records = await client.send(listCommand);
+                            
+                            console.log('Found records:', JSON.stringify(records, null, 2));
+                            
+                            // Delete all non-NS and non-SOA records
+                            for (const record of records.ResourceRecordSets) {
+                                if (record.Type !== 'NS' && record.Type !== 'SOA') {
+                                    console.log('Deleting record:', JSON.stringify(record, null, 2));
+                                    const changeCommand = new ChangeResourceRecordSetsCommand({
+                                        HostedZoneId: zoneId,
+                                        ChangeBatch: {
+                                            Changes: [{
+                                                Action: 'DELETE',
+                                                ResourceRecordSet: record
+                                            }]
+                                        }
+                                    });
+                                    await client.send(changeCommand);
+                                    console.log('Successfully deleted record');
+                                }
+                            }
+                            console.log('Cleanup completed successfully');
+                        } catch (error) {
+                            console.error('Error during cleanup:', error);
+                            throw error;
+                        }
+                    }
+                    return;
+                }
+            `)
+            })
+        });
+
+        // Give the cleanup function necessary permissions
+        cleanupProvider.onEventHandler.addToRolePolicy(new iam.PolicyStatement({
+            actions: ['route53:ListResourceRecordSets', 'route53:ChangeResourceRecordSets'],
+            resources: [`arn:aws:route53:::hostedzone/${this.subDomainHostedZone.hostedZoneId}`]
+        }));
+
+        new cdk.CustomResource(this, 'ZoneCleanup', {
+            serviceToken: cleanupProvider.serviceToken,
+            properties: {
+                hostedZoneId: this.subDomainHostedZone.hostedZoneId
+            }
         });
     }
 
@@ -56,6 +135,21 @@ export class DxDns extends Construct {
             throw new Error('Invalid subDomainName. It must be a valid subdomain like "dev.example.com".');
         }
         return `${domainParts[domainParts.length - 2]}.${domainParts[domainParts.length - 1]}`;
+    }
+
+    public get hostedZone(): route53.IHostedZone {
+        if (!this.subDomainHostedZone) {
+            throw new Error('Subdomain hosted zone has not been created yet.');
+        }
+        return this.subDomainHostedZone;
+    }
+
+    // Add getter for the hosted zone ID
+    public get zoneId(): string {
+        if (!this.subDomainHostedZone) {
+            throw new Error('Subdomain hosted zone has not been created yet.');
+        }
+        return this.subDomainHostedZone.hostedZoneId;
     }
 
     public outputNameServers(): void {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -14,7 +14,7 @@ export { BucketProfile } from './S3/dx-bucket';
 export interface DxBucketProps {}
 
 // Export constructs and props for the SslCert module
-export { SslCertStack } from './ACM/ssl_cert'
+export { DxCertificate } from './ACM/ssl_cert'
 export interface SslCertStackProps {}
 
 // Export constructs and props for the RootDelegationRole module


### PR DESCRIPTION
Added a lambda to the dns component so that we can clean up any records in route53 and delete the domain with the CDK.  Also updated ssl cert code so that we can delete the ssl certs on cdk destroy